### PR TITLE
Unwrap echoes sequentially in unwrap_individual!

### DIFF
--- a/src/unwrapping.jl
+++ b/src/unwrapping.jl
@@ -150,7 +150,7 @@ unwrap_individual, unwrap_individual!
 unwrap_individual(wrapped; keyargs...) = unwrap_individual!(copy(wrapped); keyargs...)
 function unwrap_individual!(wrapped::AbstractArray{T,4}; TEs, keyargs...) where T
     args = Dict{Symbol,Any}(keyargs)
-    Threads.@threads for i in 1:length(TEs)
+    for i in 1:length(TEs) # sequential: echo i uses the already unwrapped echo i-1 as phase2
         e2 = if (i == 1) 2 else i-1 end
         if haskey(keyargs, :mag) args[:mag] = keyargs[:mag][:,:,:,i] end
         unwrap!(view(wrapped,:,:,:,i); phase2=wrapped[:,:,:,e2], TEs=TEs[[i,e2]], args...)


### PR DESCRIPTION
`unwrap_individual!` is not reproducible under multithreading. Two identical calls can put up to 14 % of in-mask voxels on a different 2π branch.

**Revised since first opening this PR** — the original version kept the threading and snapshotted `phase2` before the loop. Measurement showed that was wrong; see "Why not keep the threading" below.

## The two races

```julia
args = Dict{Symbol,Any}(keyargs)
Threads.@threads for i in 1:length(TEs)
    e2 = if (i == 1) 2 else i-1 end
    if haskey(keyargs, :mag) args[:mag] = keyargs[:mag][:,:,:,i] end   # shared Dict, written by every task
    unwrap!(view(wrapped,:,:,:,i); phase2=wrapped[:,:,:,e2], ...)      # reads a slice another task is writing
end
```

1. **`args` is one `Dict` shared by all tasks and mutated inside the loop.** Task *i* writes its magnitude, task *j* overwrites it, then task *i* splats `args...` and unwraps its echo with **echo *j*'s magnitude**. The magnitude feeds `magcoherence`/`magweight`, so the edge weights and the spanning tree change. (`Dict` is also not safe for concurrent `setindex!`.)
2. **`phase2=wrapped[:,:,:,e2]` reads a slice another task is unwrapping in place.**

## Measured

3-echo volume, 76×76×46, TEs 14.8/34.38/53.94 ms, `JULIA_NUM_THREADS=4`, runs per path, counting in-mask voxels differing from run 1 (85 626 in-mask voxels):

| path | before | after |
| --- | --- | --- |
| temporal (default) | 0, 0, 0, 0 | 0, 0, 0, 0 |
| `individual` without a magnitude | 0, 0, 0, 0 | 0, 0, 0, 0 |
| `individual` with a magnitude | 0, 1088, 4018, 4862 | 0, 0, 0, 0, 0, 0 |
| `individual` + `correctglobal` | 0, 0, 11795, 12413 | 0, 0, 0, 0, 0, 0 |

Excursions reached 44 rad (7 wraps). `correctglobal` did not help — `correct_multi_echo_wraps!` estimates its per-echo offsets from already-racy echoes. Dropping the magnitude was deterministic even before the fix, which pins race 1 as the dominant one: `args[:mag]` is the only statement that mutates the shared `Dict`, and it only runs when a magnitude is present.

## The change

```diff
-    Threads.@threads for i in 1:length(TEs)
+    for i in 1:length(TEs) # sequential: echo i uses the already unwrapped echo i-1 as phase2
```

With one task the shared `Dict` and the in-place slice read are both safe again.

## Why not keep the threading

The obvious alternative is to keep `Threads.@threads` and snapshot the reference echoes before the loop, so each echo gets the wrapped `phase2`. I implemented that first and measured it — it is a regression.

Echo *i* referencing the **already unwrapped** echo *i-1* is load-bearing, not an artifact. With equal echo times `seedcorrection!` reduces to matching the seed against `phase2` modulo 2π, so an unwrapped reference anchors each volume to the previous one's absolute phase and the chain stays consistent. A wrapped reference determines each seed only modulo 2π and the volumes drift apart.

On the 170-volume EPI series from `medic_bench` (76×76×46×170, `-t epi -i`), counting in-mask voxels whose phase jumps by more than π between consecutive volumes:

| variant | volume-to-volume \|Δφ\| > π |
| --- | --- |
| snapshotted (wrapped) reference | 3 874 678 / 14 228 110 (**27.2 %**) |
| current chained reference | 339 931 / 14 228 110 (2.4 %) |
| temporal unwrapping, for scale | 0 / 14 228 110 (0.0 %) |

So the order has to be preserved, and preserving it deterministically means running sequentially.

**Cost.** On that 170-volume series, `-i` goes from 9.7–10.5 s to 10.8–12.4 s (~10–18 % slower) and peak RSS drops from 2.05 GB to 1.67 GB. The loss is small because `calculateweights` still threads internally over `dim in 1:3`, and it now gets the threads to itself.

**Benefit beyond determinism:** the output is bit-identical to what the current code produces single-threaded, so nothing downstream changes. Verified on the 170-volume series against niimath's port, which reproduces this behaviour: **0 of 45 168 320 voxels differ**.

## Tests

`features.jl`, `specialcases.jl`, `dsp_tests.jl`, `mri.jl`, `voxelquality.jl` — **192 passed, 0 failed** with `JULIA_NUM_THREADS=4` on Julia 1.12.3, MriResearchTools 3.5.0.

One note: the allocation assertions at `mri.jl:60-62` are cache-sensitive. The first run after *any* source edit recompiles and reports ~1.27 M pool allocations against a 7 000 limit; the next run passes. I saw this with an unrelated edit too, so it is a property of the test rather than of this change — but it may be worth a warm-up call before those three assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtQAtVA2B3ZPgAhtuBbs9j