### PR TITLE
Write Float32 outputs

### DIFF
--- a/ext/RomeoApp/caller.jl
+++ b/ext/RomeoApp/caller.jl
@@ -269,4 +269,8 @@ function write_qualitymap(settings, data, keyargs)
     end
 end
 
-save(image, name, settings::Dict) = savenii(image, name, settings["output"], settings["header"])
+to_output_type(image::AbstractArray{Float32}) = image
+to_output_type(image::AbstractArray{<:AbstractFloat}) = Float32.(image)
+to_output_type(image) = image
+
+save(image, name, settings::Dict) = savenii(to_output_type(image), name, settings["output"], settings["header"])


### PR DESCRIPTION
`B0.nii` and `B0_snr.nii` are written as Float64; every other output is Float32. They are twice the size for no information — and the inconsistency is invisible until you check the header.

| output | before | after |
| --- | --- | --- |
| `unwrapped.nii` | Float32 | Float32 |
| `mask.nii` | Float32 | Float32 |
| `quality*.nii` | Float32 | Float32 |
| `B0.nii`, `B0_snr.nii` | **Float64** | **Float32** |

## The change

All eleven output sites already funnel through one `save` helper, so the conversion goes there:

```julia
to_output_type(image::AbstractArray{Float32}) = image
to_output_type(image::AbstractArray{<:AbstractFloat}) = Float32.(image)
to_output_type(image) = image

save(image, name, settings::Dict) = savenii(to_output_type(image), name, settings["output"], settings["header"])
```

Three points behind that shape:

- **Only floating-point results are narrowed.** The `regions` map (`UInt8`) and the mask (`BitArray`) fall to the passthrough method, so this PR does not change them. They are already converted to Float32 further down by `MriResearchTools.savenii`'s `ConvertTypes` method — worth revisiting separately, but not here.
- **Already-Float32 arrays are returned untouched**, so the unwrapped phase is not copied. That matters: on a 170-volume series it is a 181 MB array.
- **Dispatch rather than a branch**, so the conversion is resolved at compile time and `save` stays a one-liner.

## Precision

Not a judgement call — the margin is large.

- B0 on the test volume spans −174 … 239 Hz. One Float32 ULP at 239 Hz is 2.8·10⁻⁵ Hz.
- The physical noise floor is ~0.08 Hz (≈0.01 rad phase noise at TE ≈ 20 ms). Float32 quantisation sits **~3000× below** it.
- The input is uint16 with 4096 levels over 2π, i.e. a 1.5·10⁻³ rad quantum; Float32 resolves that by three orders of magnitude.

Measured, 3-echo volume, `-B --phase-offset-correction off`:

| comparison | result |
| --- | --- |
| new Float32 B0 vs old Float64 B0 | max \|diff\| 7.6·10⁻⁶ Hz (below one Float32 ULP) |
| new Float32 B0_snr vs old Float64 | max \|diff\| 1.8·10⁻³ on values up to 3.7·10⁴ (rel. 5·10⁻⁸) |
| `unwrapped.nii`, `mask.nii`, `quality*.nii` | unchanged, 0 voxels differ |

File size for B0 and B0_snr halves, 2 125 920 → 1 063 136 bytes each per volume.

A side effect worth noting: niimath's `-romeo` port writes Float32 here, so the two now agree **exactly** — B0 and B0_snr are byte-identical (0 of 265 696 voxels differ), where before they differed by the storage rounding alone.

## Compatibility

Float32 is the de-facto NIfTI convention that FSL/SPM/AFNI expect, and readers take the type from the header, so this should be invisible to consumers. It is still a stored-format change for anyone diffing against archived Float64 files — probably worth a line in the release notes.

## Tests

`features.jl`, `specialcases.jl`, `dsp_tests.jl`, `mri.jl`, `voxelquality.jl` — **192 passed, 0 failed** with `JULIA_NUM_THREADS=4` on Julia 1.12.3, MriResearchTools 3.5.0.

(The allocation assertions at `mri.jl:60-62` fail on the first run after *any* edit to the sources, because the recompile is charged to the first measured call; the next run passes. Same behaviour with unrelated edits — a warm-up call before those three assertions would make them robust.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CtQAtVA2B3ZPgAhtuBbs9j

---
_Generated by [Claude Code](https://claude.ai/code/session_01CtQAtVA2B3ZPgAhtuBbs9j)_