### PR TITLE
Add phase singularity detection and local correction

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,13 @@ mask = singularity_mask(s)   # voxels on a vortex line
 cuts = branchcuts(unwrapped) # faces with a remaining 2π jump
 ```
 
-The singularity mask can be used as a data term weight for a QSM inversion, but at high resolution it needs filtering first: in 0.35 mm 7T data at TE = 23 ms the unfiltered mask covers about 20% of the brain, because low SNR per voxel produces a dense network of noise residues. Filtering on loop length and requiring the line to touch a signal void isolates the vessel related singularities (`singularity_mask(s; min_length=21)` and the `mag_threshold` gate of `fix_singularities!`).
+At high resolution the raw residue field is dominated by noise: in 0.35 mm 7T data at TE = 23 ms it covers about 20% of the brain and percolates into a single connected network of 155000 plaquettes. Detecting on the complex signal smoothed with `sigma` removes it, because noise residues annihilate as ± pairs inside the kernel while a vortex line around a vessel survives:
+
+```julia
+s = detect_singularities(unwrapped; mag, sigma=1)
+```
+
+In the same data this leaves 30500 instead of 399000 vortex lines, the largest one shrinks from 155000 to 604 plaquettes and the mask covers 0.97% of the brain instead of 29%, which makes it usable as a data term weight for a QSM inversion. The price is a low pass on vessel size: on the vein phantom (0.3 mm voxels) `sigma=0.7` already annihilates the singularities of a vessel with 0.25 mm radius, `sigma=1.5` those of a 0.45 mm vessel and `sigma=2` those of a 0.8 mm vessel. Choose `sigma` below the radius in voxels of the smallest vessel that still matters. Filtering on loop length and on the magnitude gate (`singularity_mask(s; min_length=21)`) works in the same direction.
 
 The phase can also be corrected locally, which keeps the result bit-identical outside of small patches around the vortex lines:
 
@@ -77,7 +83,9 @@ info.nfixed, info.nskipped, info.nchanged
 info.delta # the applied correction, φ_corrected - φ_ROMEO
 ```
 
-On the command line, `--fix-singularities [off|mask|cascade|smooth|lsq|inpaint]` (default `off`) writes `singularities.nii` and `branchcuts.nii`, and for the correcting modes also `phase_correction.nii`. Loops that are too long, too large or that are not in a signal void are only marked, never modified, which protects real pathology (microbleeds, implants).
+On the command line, `--fix-singularities [off|mask|cascade|smooth|lsq|inpaint]` (default `off`) writes `singularities.nii` and `branchcuts.nii`, and for the correcting modes also `phase_correction.nii`. `--singularity-sigma` sets the detection smoothing described above. Loops that are too long, too large or that are not in a signal void are only marked, never modified, which protects real pathology (microbleeds, implants).
+
+A caveat on the correcting modes: they only work where the vortex line and its branch cut can be enclosed by a small patch. In single-run 0.35 mm 7T data the branch cut surface itself percolates (20 million faces with a jump above π inside the brain mask), so almost every patch is rejected by the size limit and the number of remaining jumps is unchanged. There the honest answer is `mask` - mark the voxels and downweight them in the inversion - or better SNR (averaging, denoising) before unwrapping. The correcting modes are aimed at data where the singularities are isolated.
 
 ### Setting the Template Echo
 In certain cases, the phase of the first echo/time-point looks differently than the rest of the acquisition, which can occur due to flow compensation of only the first echo or not having reached the steady state in fMRI. This might cause template unwrapping to fail, as the first echo is chosen as the template by default.  

--- a/README.md
+++ b/README.md
@@ -67,7 +67,9 @@ mask = singularity_mask(s)   # voxels on a vortex line
 cuts = branchcuts(unwrapped) # faces with a remaining 2π jump
 ```
 
-The singularity mask alone is already useful as a data term weight for a QSM inversion. The phase can also be corrected locally, which keeps the result bit-identical outside of small patches around the vortex lines:
+The singularity mask can be used as a data term weight for a QSM inversion, but at high resolution it needs filtering first: in 0.35 mm 7T data at TE = 23 ms the unfiltered mask covers about 20% of the brain, because low SNR per voxel produces a dense network of noise residues. Filtering on loop length and requiring the line to touch a signal void isolates the vessel related singularities (`singularity_mask(s; min_length=21)` and the `mag_threshold` gate of `fix_singularities!`).
+
+The phase can also be corrected locally, which keeps the result bit-identical outside of small patches around the vortex lines:
 
 ```julia
 info = fix_singularities!(unwrapped; mag, mode=:cascade)

--- a/README.md
+++ b/README.md
@@ -54,6 +54,29 @@ For proper handling, the phase offsest can be removed using `mcpc3ds` from `MriR
 ### Repeated Measurements (EPI)
 4D data with an equal echo time for all volumes should be unwrapped as 4D for best accuracy and temporal stability. The echo times can be set to `TEs=ones(size(phase,4))`
 
+### Phase Singularities around Veins (experimental)
+In high resolution data (e.g. 7T, 0.3-0.6 mm, TE >= 20 ms) the complex signal can cross zero at a vessel wall, where two compartments with roughly opposite phase cancel each other. At such a point the wrapped phase has a non-zero circulation (a residue), which is a topological obstruction: no congruent unwrapping exists. In 3D the residue field is divergence free, so the residues form closed lines, around a vein typically rings that encircle the vessel. ROMEO stays congruent and therefore has to keep the resulting branch cut, it only moves it to the worst weights.
+
+Detection is parameter free and can be run on the wrapped input or on the unwrapped output:
+
+```julia
+using ROMEO
+unwrapped = unwrap(phase; mag)
+s = detect_singularities(unwrapped)
+mask = singularity_mask(s)   # voxels on a vortex line
+cuts = branchcuts(unwrapped) # faces with a remaining 2π jump
+```
+
+The singularity mask alone is already useful as a data term weight for a QSM inversion. The phase can also be corrected locally, which keeps the result bit-identical outside of small patches around the vortex lines:
+
+```julia
+info = fix_singularities!(unwrapped; mag, mode=:cascade)
+info.nfixed, info.nskipped, info.nchanged
+info.delta # the applied correction, φ_corrected - φ_ROMEO
+```
+
+On the command line, `--fix-singularities [off|mask|cascade|smooth|lsq|inpaint]` (default `off`) writes `singularities.nii` and `branchcuts.nii`, and for the correcting modes also `phase_correction.nii`. Loops that are too long, too large or that are not in a signal void are only marked, never modified, which protects real pathology (microbleeds, implants).
+
 ### Setting the Template Echo
 In certain cases, the phase of the first echo/time-point looks differently than the rest of the acquisition, which can occur due to flow compensation of only the first echo or not having reached the steady state in fMRI. This might cause template unwrapping to fail, as the first echo is chosen as the template by default.  
 With the optional argument `template=2`, this can be changed to the second (or any other) echo/time-point.

--- a/ext/RomeoApp/argparse.jl
+++ b/ext/RomeoApp/argparse.jl
@@ -148,6 +148,23 @@ function getargs(args::AbstractVector, version)
                 (π + wrap-addition) phase difference."""
             arg_type = Float64
             default = 0.0
+        "--fix-singularities"
+            help = """off | mask | cascade | smooth | lsq | inpaint.
+                EXPERIMENTAL! Detects phase singularities (residues, the vortex
+                lines that typically encircle veins in high resolution data)
+                and writes them to singularities.nii and branchcuts.nii.
+                "mask" only detects, the mask can be used as a data term weight
+                for QSM. The other options additionally remove the singularity
+                in a small patch around it, everything outside the patch stays
+                bit-identical. "cascade" (recommended) annihilates small loops
+                with complex smoothing and solves a magnitude weighted
+                least-squares problem around larger loops, "inpaint" replaces
+                the patch harmonically and "lsq"/"smooth" force the respective
+                method for all loops. The applied correction is written to
+                phase_correction.nii."""
+            default = "off"
+            nargs = '?'
+            constant = "mask"
         "--temporal-uncertain-unwrapping"
             help = """EXPERIMENTAL! Uses spatial unwrapping on voxels that have
                 low quality values after temporal unwrapping. A higher threshold

--- a/ext/RomeoApp/argparse.jl
+++ b/ext/RomeoApp/argparse.jl
@@ -165,6 +165,17 @@ function getargs(args::AbstractVector, version)
             default = "off"
             nargs = '?'
             constant = "mask"
+        "--singularity-sigma"
+            help = """EXPERIMENTAL! Kernel width in voxels used to detect the
+                singularities on the complex-smoothed signal instead of on the
+                phase itself. 0 (default) detects every residue, which at high
+                resolution is dominated by a percolating network of noise
+                residues. A positive value annihilates those, but also removes
+                the singularities of vessels smaller than about this radius in
+                voxels. Values around 0.7-1.0 are a reasonable starting point
+                for submillimeter data."""
+            arg_type = Float64
+            default = 0.0
         "--temporal-uncertain-unwrapping"
             help = """EXPERIMENTAL! Uses spatial unwrapping on voxels that have
                 low quality values after temporal unwrapping. A higher threshold

--- a/ext/RomeoApp/caller.jl
+++ b/ext/RomeoApp/caller.jl
@@ -242,9 +242,11 @@ function correct_singularities(data, settings)
         error("fix-singularities option '$(settings["fix-singularities"])' is undefined! Use one of $(join(ROMEO.SINGULARITY_MODES, ", "))")
     end
     settings["verbose"] && println("detect singularities ($mode)...")
-    args = Dict{Symbol,Any}(:mode => mode)
+    args = Dict{Symbol,Any}(:mode => mode, :detection_sigma => settings["singularity-sigma"])
     if haskey(data, "mag") args[:mag] = data["mag"] end
     if haskey(data, "mask") args[:mask] = data["mask"] end
+    settings["verbose"] && settings["singularity-sigma"] > 0 &&
+        println("detecting on the complex signal smoothed with sigma=$(settings["singularity-sigma"])")
 
     info = ROMEO.fix_singularities!(data["phase"]; args...)
 

--- a/ext/RomeoApp/caller.jl
+++ b/ext/RomeoApp/caller.jl
@@ -17,7 +17,11 @@ function ROMEO.unwrapping_main(args; version="App 4.5")
     keyargs = get_keyargs(settings, data)
 
     unwrapping(data, settings, keyargs)
-    
+
+    if settings["fix-singularities"] != "off"
+        correct_singularities(data, settings)
+    end
+
     if settings["threshold"] != Inf
         max = settings["threshold"] * 2π
         data["phase"][data["phase"] .> max] .= 0
@@ -230,6 +234,29 @@ function unwrapping(data, settings, keyargs)
         settings["verbose"] && println("writing regions...")
         save(regions, "regions", settings)
     end
+end
+
+function correct_singularities(data, settings)
+    mode = Symbol(settings["fix-singularities"])
+    if mode ∉ ROMEO.SINGULARITY_MODES
+        error("fix-singularities option '$(settings["fix-singularities"])' is undefined! Use one of $(join(ROMEO.SINGULARITY_MODES, ", "))")
+    end
+    settings["verbose"] && println("detect singularities ($mode)...")
+    args = Dict{Symbol,Any}(:mode => mode)
+    if haskey(data, "mag") args[:mag] = data["mag"] end
+    if haskey(data, "mask") args[:mask] = data["mask"] end
+
+    info = ROMEO.fix_singularities!(data["phase"]; args...)
+
+    save(UInt8.(info.singularities), "singularities", settings)
+    save(UInt8.(info.cuts), "branchcuts", settings)
+    if mode != :mask
+        save(UInt8.(info.changed), "singularities_corrected", settings)
+        save(info.delta, "phase_correction", settings)
+    end
+    settings["verbose"] && println("$(info.nloops) singularity loops ($(info.nresidues) residues), " *
+        "$(info.nfixed) corrected, $(info.nskipped) only marked, $(info.nchanged) voxels changed")
+    return info
 end
 
 function computeB0(settings, data)

--- a/src/ROMEO.jl
+++ b/src/ROMEO.jl
@@ -13,9 +13,13 @@ include("region_handling.jl")
 include("algorithm.jl")
 include("unwrapping.jl")
 include("voxelquality.jl")
+include("singularities.jl")
+include("singularity_correction.jl")
 
 unwrapping_main(args...; kwargs...) = @warn("Type `using ArgParse` to use this function \n `?unwrapping_main` for argument help")
 
 export unwrap, unwrap!, unwrap_individual, unwrap_individual!, voxelquality, unwrapping_main
+export detect_singularities, residues, singularity_mask, branchcuts, congruence_error
+export fix_singularities, fix_singularities!
 
 end # module

--- a/src/singularities.jl
+++ b/src/singularities.jl
@@ -1,0 +1,310 @@
+## Phase singularity (residue / vortex line) detection
+#
+# A residue is a non-zero circulation of the wrapped phase differences around a
+# 2x2 plaquette. Where it occurs, no integer field n(x) exists that makes
+# φ + 2πn continuous everywhere. This is a topological obstruction and not a
+# shortcoming of the unwrapping algorithm. Physically a singularity sits where
+# the complex signal vanishes (Re(S) = 0 and Im(S) = 0), which is a line in 3D.
+# The dominant cause in high resolution data is partial voluming at a vessel
+# wall, where two compartments with ~π phase difference cancel each other.
+#
+# In 3D the residue field is divergence free (the charges of the 6 faces of a
+# voxel cube sum to zero), therefore residues form closed lines, around a vein
+# typically rings that enclose the vessel.
+#
+# The residues only depend on the wrapped phase differences and are therefore
+# invariant under adding n2π to individual voxels. They can be computed from
+# the wrapped input as well as from the congruent ROMEO output.
+
+# normal dimension -> the two dimensions spanned by the plaquette (cyclic, so
+# that the residue field is divergence free)
+const PLAQUETTE_DIMS = ((2, 3), (3, 1), (1, 2))
+
+unitindex(d) = CartesianIndex(ntuple(i -> Int(i == d), 3))
+
+tomask(mask) = isnothing(mask) ? nothing : BitArray(mask .!= 0)
+tomask(mask::BitArray) = mask
+
+# 1D and 2D input is handled as 3D with singleton dimensions, like `unwrap`
+const LowDim{T} = Union{AbstractArray{T,1},AbstractArray{T,2}}
+to3d(x) = reshape(x, size(x)..., ntuple(_ -> 1, 3 - ndims(x))...)
+to3d(::Nothing) = nothing
+
+"""
+    residues(phase::AbstractArray{<:Real,3}; mask=nothing)
+
+Charge of every 2x2 plaquette of the phase (Goldstein residues, extended to 3D).
+
+`residues(phase)[c,i,j,k]` is the charge (`-1`, `0` or `1`) of the plaquette
+with the corner voxel `(i,j,k)` that is normal to the dimension `c`. The
+returned field is divergence free, non-zero plaquettes therefore form closed
+lines (see [`detect_singularities`](@ref)).
+
+Wrapped and unwrapped (congruent) phase give the identical result.
+"""
+function residues(phase::AbstractArray{<:Real,3}; mask=nothing)
+    sz = size(phase)
+    mask = tomask(mask)
+    res = zeros(Int8, 3, sz...)
+    Threads.@threads for k in 1:sz[3] # threading over slices to avoid write conflicts
+        for c in 1:3
+            a, b = PLAQUETTE_DIMS[c]
+            (k == sz[3] && (a == 3 || b == 3)) && continue
+            ea, eb = unitindex(a), unitindex(b)
+            ranges = (1:(sz[1] - (a == 1 || b == 1)), 1:(sz[2] - (a == 2 || b == 2)), k:k)
+            for I in CartesianIndices(ranges)
+                if !isnothing(mask) && !(mask[I] && mask[I+ea] && mask[I+eb] && mask[I+ea+eb])
+                    continue
+                end
+                s = rem2pi(phase[I+ea] - phase[I], RoundNearest) +
+                    rem2pi(phase[I+ea+eb] - phase[I+ea], RoundNearest) +
+                    rem2pi(phase[I+eb] - phase[I+ea+eb], RoundNearest) +
+                    rem2pi(phase[I] - phase[I+eb], RoundNearest)
+                if isfinite(s)
+                    res[c, I] = round(Int8, s / 2π)
+                end
+            end
+        end
+    end
+    return res
+end
+
+"""
+    SingularityLoop
+
+One connected component of the residue field, i.e. one vortex line.
+
+- `plaquettes`: linear indices into the `(3, size(phase)...)` residue array
+- `voxels`: linear indices of the voxels touched by these plaquettes
+- `closed`: `true` if the line closes inside the volume (and mask). Open lines
+    end at the volume or mask border and cannot be corrected consistently.
+"""
+struct SingularityLoop
+    plaquettes::Vector{Int}
+    voxels::Vector{Int}
+    closed::Bool
+end
+
+loop_length(l::SingularityLoop) = length(l.plaquettes)
+
+"""
+    Singularities
+
+Result of [`detect_singularities`](@ref): the residue field and the vortex
+lines (`loops`) it forms.
+"""
+struct Singularities
+    residues::Array{Int8,4}
+    loops::Vector{SingularityLoop}
+    size::NTuple{3,Int}
+end
+
+"""
+    detect_singularities(phase::AbstractArray{<:Real,3}; mask=nothing)
+
+Detect phase singularities and group them into vortex lines.
+
+The phase can be the wrapped input or the unwrapped ROMEO output, both give the
+same result. Detection is parameter free and O(N), it is the definition of the
+problem rather than a heuristic.
+
+# Examples
+```julia-repl
+julia> unwrapped = unwrap(phase; mag);
+julia> s = detect_singularities(unwrapped);
+julia> sum(abs, s.residues) # number of residue plaquettes
+julia> savenii(singularity_mask(s), "singularities.nii"; header=header(phase));
+```
+
+See also [`singularity_mask`](@ref), [`branchcuts`](@ref),
+[`fix_singularities!`](@ref)
+"""
+function detect_singularities(phase::AbstractArray{<:Real,3}; mask=nothing)
+    res = residues(phase; mask)
+    return Singularities(res, find_loops(res), size(phase))
+end
+
+detect_singularities(phase::AbstractArray{<:Real,4}; keyargs...) =
+    [detect_singularities(view(phase, :, :, :, i); keyargs...) for i in 1:size(phase, 4)]
+
+residues(phase::LowDim{<:Real}; mask=nothing) = residues(to3d(phase); mask=to3d(mask))
+detect_singularities(phase::LowDim{<:Real}; mask=nothing) = detect_singularities(to3d(phase); mask=to3d(mask))
+
+## loop extraction
+struct UnionFind
+    parent::Vector{Int}
+end
+UnionFind(n::Integer) = UnionFind(collect(1:n))
+function findroot(uf::UnionFind, x)
+    while uf.parent[x] != x
+        uf.parent[x] = uf.parent[uf.parent[x]]
+        x = uf.parent[x]
+    end
+    return x
+end
+function unite!(uf::UnionFind, a, b)
+    ra, rb = findroot(uf, a), findroot(uf, b)
+    if ra != rb
+        uf.parent[rb] = ra
+    end
+end
+
+# position of `value` in the sorted vector `sorted`, 0 if not present
+function sorted_lookup(sorted, value)
+    i = searchsortedfirst(sorted, value)
+    return (i ≤ length(sorted) && sorted[i] == value) ? i : 0
+end
+
+iscompletecube(J, sz) = all(d -> 1 ≤ J[d] < sz[d], 1:3)
+
+# divergence of the residue field over the cube with the corner J
+function cube_divergence(res, J)
+    div = 0
+    for d in 1:3
+        e = unitindex(d)
+        if checkbounds(Bool, res, d, J)
+            div -= res[d, J]
+        end
+        if checkbounds(Bool, res, d, J + e)
+            div += res[d, J+e]
+        end
+    end
+    return div
+end
+
+# Two residue plaquettes belong to the same vortex line if they are faces of a
+# common voxel cube. The divergence free residue field guarantees that the
+# lines are closed as long as they don't leave the volume or the mask.
+function find_loops(res::AbstractArray{Int8,4})
+    sz = size(res)[2:4]
+    lin = LinearIndices(res)
+    linvox = LinearIndices(sz)
+    idx = findall(!iszero, res)
+    plaquettes = [lin[K] for K in idx] # ascending, `findall` returns linear order
+    uf = UnionFind(length(idx))
+    for (k, K) in enumerate(idx)
+        c = K[1]
+        I = CartesianIndex(K[2], K[3], K[4])
+        for J in (I, I - unitindex(c)) # the two cubes sharing this plaquette
+            all(>(0), Tuple(J)) || continue
+            for d in 1:3, F in (J, J + unitindex(d)) # the 6 faces of the cube
+                checkbounds(Bool, res, d, F) || continue
+                iszero(res[d, F]) && continue # cheap test before the lookup
+                q = sorted_lookup(plaquettes, lin[d, F])
+                if q != 0
+                    unite!(uf, k, q)
+                end
+            end
+        end
+    end
+
+    groups = Dict{Int,Vector{Int}}()
+    for k in eachindex(idx)
+        push!(get!(groups, findroot(uf, k), Int[]), k)
+    end
+
+    loops = SingularityLoop[]
+    for ks in values(groups)
+        voxels = Set{Int}()
+        closed = true
+        for k in ks
+            K = idx[k]
+            c = K[1]
+            I = CartesianIndex(K[2], K[3], K[4])
+            a, b = PLAQUETTE_DIMS[c]
+            ea, eb = unitindex(a), unitindex(b)
+            for V in (I, I + ea, I + eb, I + ea + eb)
+                push!(voxels, linvox[V])
+            end
+            for J in (I, I - unitindex(c))
+                if !iscompletecube(J, sz) || cube_divergence(res, J) != 0
+                    closed = false
+                end
+            end
+        end
+        push!(loops, SingularityLoop(sort!([lin[idx[k]] for k in ks]), sort!(collect(voxels)), closed))
+    end
+    sort!(loops; by=l -> (-loop_length(l), l.plaquettes[1])) # deterministic order
+    return loops
+end
+
+## masks
+"""
+    singularity_mask(s::Singularities; min_length=1, max_length=Inf, closed_only=false)
+
+Voxel mask of all voxels that are touched by a vortex line. `min_length` and
+`max_length` filter on the number of residue plaquettes of a line. Loops with a
+length of 4 are the smallest possible ones and are usually harmless noise.
+"""
+function singularity_mask(s::Singularities; min_length=1, max_length=Inf, closed_only=false)
+    m = falses(s.size)
+    for l in s.loops
+        min_length ≤ loop_length(l) ≤ max_length || continue
+        closed_only && !l.closed && continue
+        m[l.voxels] .= true
+    end
+    return m
+end
+
+"""
+    branchcuts(unwrapped::AbstractArray{<:Real,3}; threshold=π, mask=nothing)
+
+Faces (connections between neighboring voxels) at which the unwrapped phase
+jumps by more than `threshold`. These are the remaining branch cuts of the
+congruent unwrapping, the surfaces that are bounded by the vortex lines.
+
+`branchcuts(unwrapped)[d,i,j,k]` refers to the face between `(i,j,k)` and its
+neighbor in the dimension `d`. Note that large true field jumps (air-tissue
+interfaces) also show up here.
+"""
+function branchcuts(unwrapped::AbstractArray{<:Real,3}; threshold=Float64(π), mask=nothing)
+    sz = size(unwrapped)
+    mask = tomask(mask)
+    cuts = falses(3, sz...)
+    for d in 1:3
+        e = unitindex(d)
+        ranges = ntuple(t -> 1:(sz[t] - (t == d)), 3)
+        for I in CartesianIndices(ranges)
+            if !isnothing(mask) && !(mask[I] && mask[I+e])
+                continue
+            end
+            jump = unwrapped[I+e] - unwrapped[I]
+            cuts[d, I] = isfinite(jump) && abs(jump) > threshold
+        end
+    end
+    return cuts
+end
+
+branchcuts(unwrapped::LowDim{<:Real}; mask=nothing, keyargs...) =
+    branchcuts(to3d(unwrapped); mask=to3d(mask), keyargs...)
+
+"""
+    facemask_to_voxelmask(faces)
+
+Reduce a face mask of size `(3, size...)` (as returned by [`branchcuts`](@ref))
+to the mask of the voxels that are connected by these faces.
+"""
+function facemask_to_voxelmask(faces::AbstractArray{Bool,4})
+    sz = size(faces)[2:4]
+    m = falses(sz)
+    for d in 1:3
+        e = unitindex(d)
+        ranges = ntuple(t -> 1:(sz[t] - (t == d)), 3)
+        for I in CartesianIndices(ranges)
+            if faces[d, I]
+                m[I] = true
+                m[I+e] = true
+            end
+        end
+    end
+    return m
+end
+
+"""
+    congruence_error(corrected, original)
+
+Deviation from congruence (`Δ ∈ 2πℤ`) between two phase images in radians.
+Zero everywhere means that the corrected phase is still a valid unwrapping of
+the input. Useful as a protection metric for [`fix_singularities!`](@ref).
+"""
+congruence_error(corrected, original) = abs.(rem2pi.(corrected .- original, RoundNearest))

--- a/src/singularities.jl
+++ b/src/singularities.jl
@@ -100,13 +100,28 @@ struct Singularities
 end
 
 """
-    detect_singularities(phase::AbstractArray{<:Real,3}; mask=nothing)
+    detect_singularities(phase::AbstractArray{<:Real,3}; mask=nothing, mag=nothing, sigma=0)
 
 Detect phase singularities and group them into vortex lines.
 
 The phase can be the wrapped input or the unwrapped ROMEO output, both give the
-same result. Detection is parameter free and O(N), it is the definition of the
-problem rather than a heuristic.
+same result. With `sigma=0` the detection is parameter free and O(N), it is the
+definition of the problem rather than a heuristic.
+
+### Optional keyword arguments
+
+- `mask`: only detect inside the mask
+- `mag`: magnitude, only used together with `sigma`
+- `sigma=0`: if positive, the residues are computed on the complex signal
+    `mag * exp(i*phase)` smoothed with a Gaussian of this width in voxels
+    instead of on `phase` itself. Noise residues annihilate as ± pairs inside
+    the kernel while a vortex line around a vessel survives, so this is the
+    knob that makes the detection usable at high resolution. It is not free:
+    `sigma` acts as a low pass on vessel size. On the vein phantom (0.3 mm
+    voxels) the singularities of a vessel with 0.25 mm radius are annihilated
+    at `sigma` 0.7, those of a 0.45 mm vessel at 1.5 and those of a 0.8 mm
+    vessel at 2.0. Choose `sigma` below the radius (in voxels) of the smallest
+    vessel that still matters.
 
 # Examples
 ```julia-repl
@@ -114,21 +129,40 @@ julia> unwrapped = unwrap(phase; mag);
 julia> s = detect_singularities(unwrapped);
 julia> sum(abs, s.residues) # number of residue plaquettes
 julia> savenii(singularity_mask(s), "singularities.nii"; header=header(phase));
+
+julia> s = detect_singularities(unwrapped; mag, sigma=1) # noise residues removed
 ```
 
 See also [`singularity_mask`](@ref), [`branchcuts`](@ref),
 [`fix_singularities!`](@ref)
 """
-function detect_singularities(phase::AbstractArray{<:Real,3}; mask=nothing)
+function detect_singularities(phase::AbstractArray{<:Real,3}; mask=nothing, mag=nothing, sigma=0)
+    if sigma > 0
+        phase = smoothed_phase(phase, mag, sigma, tomask(mask))
+    end
     res = residues(phase; mask)
     return Singularities(res, find_loops(res), size(phase))
+end
+
+# phase of the complex signal after Gaussian smoothing
+function smoothed_phase(phase, mag, sigma, mask)
+    S = Array{ComplexF64,3}(undef, size(phase))
+    for I in CartesianIndices(size(phase))
+        m = isnothing(mag) ? 1.0 : Float64(mag[I])
+        p = Float64(phase[I])
+        inside = isnothing(mask) || mask[I]
+        S[I] = (inside && isfinite(m) && isfinite(p)) ? m * cis(p) : zero(ComplexF64)
+    end
+    smooth_complex!(S, sigma) # defined in singularity_correction.jl
+    return angle.(S)
 end
 
 detect_singularities(phase::AbstractArray{<:Real,4}; keyargs...) =
     [detect_singularities(view(phase, :, :, :, i); keyargs...) for i in 1:size(phase, 4)]
 
 residues(phase::LowDim{<:Real}; mask=nothing) = residues(to3d(phase); mask=to3d(mask))
-detect_singularities(phase::LowDim{<:Real}; mask=nothing) = detect_singularities(to3d(phase); mask=to3d(mask))
+detect_singularities(phase::LowDim{<:Real}; mask=nothing, mag=nothing, keyargs...) =
+    detect_singularities(to3d(phase); mask=to3d(mask), mag=to3d(mag), keyargs...)
 
 ## loop extraction
 struct UnionFind

--- a/src/singularity_correction.jl
+++ b/src/singularity_correction.jl
@@ -1,0 +1,574 @@
+## Correction of phase singularities
+#
+# ROMEO is congruent (the output differs from the input by n2π in every voxel),
+# which is exactly the reason why a residue cannot disappear: the minimum
+# spanning tree only moves the branch cut to the worst weights, it cannot
+# remove it. Around a vein the vortex line encircles the vessel, so the cut
+# surface has to leave the vessel somewhere into good tissue.
+#
+# The compromise implemented here is: congruent everywhere, except in small,
+# explicitly marked patches. Every mode uses the same local weighted
+# least-squares solve
+#
+#   min_φ Σ_ij W_ij (φ_i - φ_j - D_ij)²    with Dirichlet boundary conditions
+#
+# on a box around the vortex line, with the ROMEO result as boundary values.
+# The least-squares solution keeps only the rotation free part of the field, so
+# the branch cut is gone; outside of the patch nothing changes at all. A
+# residue can only survive if the solution itself still changes by more than π
+# between two voxels. The modes only differ in how the edge confidence w and
+# the target gradient Δ are computed:
+#
+#   :lsq     w = mag², Δ from the measured wrapped phase differences
+#   :smooth  w and Δ from the complex signal smoothed with `sigma`
+#   :inpaint w = 0, Δ = 0 -> harmonic inpainting
+#   :mask    no correction, only detection
+#   :cascade small loops with :smooth, larger loops with :lsq (recommended)
+#
+# Writing W = w + ε and D = wΔ/(w+ε) turns the objective into
+# Σ w(φ_i-φ_j-Δ)² + ε Σ (φ_i-φ_j)², so w -> 0 degenerates to inpainting
+# without a second code path, and voxels with good signal (large w) keep their
+# measured phase gradients and therefore stay congruent.
+
+const SINGULARITY_MODES = (:off, :mask, :smooth, :lsq, :inpaint, :cascade)
+
+"""
+    fix_singularities!(phase; mode=:cascade, mag=nothing, mask=nothing, keyargs...)
+    fix_singularities(phase; keyargs...) -> (phase, info)
+
+Detect phase singularities in the unwrapped `phase` and remove them locally.
+EXPERIMENTAL.
+
+The unwrapped phase is only modified inside small patches around the detected
+vortex lines, everywhere else it stays bit-identical (and therefore congruent
+to the input phase). Returns a `NamedTuple` with the detection and correction
+outputs, `phase` is modified in place.
+
+### Modes
+
+- `:off`: do nothing
+- `:mask`: only detect, don't touch the phase. The mask can be used as a data
+    term weight for a downstream QSM inversion.
+- `:cascade`: (recommended) `:smooth` for small loops, `:lsq` for larger ones
+- `:smooth`: complex smoothing with `sigma` annihilates ± pairs inside the
+    kernel width. Only suitable for small loops, the winding number of a large
+    loop is topologically protected and would only be moved.
+- `:lsq`: magnitude weighted least-squares solve in the patch
+- `:inpaint`: harmonic inpainting in the patch (discards the intravascular
+    phase, use as a control arm)
+
+### Optional keyword arguments
+
+- `mag`: magnitude, used for the edge weights and for the gate
+- `mask`: only detect and correct inside the mask
+- `sigma=1.0`: kernel width in voxels for the complex smoothing
+- `small_loop_length=8`: loops up to this number of residue plaquettes are
+    treated as small in the `:cascade` mode
+- `min_loop_length=1`: shorter loops are not corrected (4 is the smallest
+    possible loop and is usually noise)
+- `max_loop_length=1000`: longer loops are only marked, never touched. This is
+    the fallback that protects real pathology (microbleeds, implants).
+- `max_patch_voxels=20000`: larger patches are only marked
+- `dilate=2`: dilation of the vortex line and its branch cut surface, defines
+    the corrected region
+- `pad=2`: width of the Dirichlet boundary ring around the patch
+- `mag_threshold=0.2`: magnitude relative to its 95th percentile below which a
+    voxel counts as a signal void
+- `min_void_voxels=1`: number of signal void voxels a vortex line has to touch
+    to be corrected at all. A singularity is a zero of the complex signal, a
+    line without a void is a different phenomenon (e.g. an aliased field
+    gradient in good tissue) and is only marked.
+- `require_closed=false`: if `true`, only lines that close inside the volume
+    are corrected. Lines that leave the volume or the mask are consistent as
+    well, as long as the patch contains everything that stays inside.
+- `epsilon=1e-3`: regularization of the least-squares problem
+- `cut_threshold=π`: phase jump above which a face counts as a branch cut
+
+### Output fields
+
+- `singularities`: voxel mask of all detected vortex lines
+- `cuts`: voxel mask of the remaining branch cuts (jumps > `cut_threshold`)
+- `changed`: voxel mask of the actually corrected voxels
+- `delta`: the correction `φ_corrected - φ_ROMEO` (empty for `:mask`/`:off`)
+- `loops`, `nloops`, `nresidues`, `nchanged`
+- `nfixed`/`nskipped`: number of vortex lines that were corrected / only marked
+
+# Examples
+```julia-repl
+julia> unwrapped = unwrap(phase; mag, TEs);
+julia> info = fix_singularities!(unwrapped; mag, mode=:cascade);
+julia> info.nfixed, info.nskipped
+julia> savenii(info.singularities, "singularities.nii"; header=header(phase));
+```
+
+See also [`detect_singularities`](@ref), [`branchcuts`](@ref)
+"""
+fix_singularities, fix_singularities!
+
+function fix_singularities(phase; keyargs...)
+    phase = copy(phase)
+    return phase, fix_singularities!(phase; keyargs...)
+end
+
+function fix_singularities!(phase::AbstractArray{T,3};
+        mode=:cascade, mag=nothing, mask=nothing,
+        sigma=1.0, small_loop_length=8, min_loop_length=1, max_loop_length=1000,
+        max_patch_voxels=20_000, dilate=2, pad=2, mag_threshold=0.2,
+        min_void_voxels=1, require_closed=false, epsilon=1e-3,
+        cut_threshold=Float64(π), keyargs...) where T
+    mode = Symbol(mode)
+    mode in SINGULARITY_MODES || throw(ArgumentError("singularity mode '$mode' is undefined! Use one of $(join(SINGULARITY_MODES, ", "))"))
+    sz = size(phase)
+    for (name, arr) in (("mag", mag), ("mask", mask))
+        if !isnothing(arr) && size(arr) != sz
+            throw(DimensionMismatch("size of $name is $(size(arr)), but the phase is $sz"))
+        end
+    end
+    correcting = mode ∉ (:off, :mask)
+    if mode == :off
+        return (; mode, singularities=falses(sz), cuts=falses(sz), changed=falses(sz),
+            delta=zeros(T, 0, 0, 0), loops=SingularityLoop[], nloops=0, nfixed=0,
+            nskipped=0, nresidues=0, nchanged=0)
+    end
+
+    mask = tomask(mask)
+    sing = detect_singularities(phase; mask)
+    cuts = branchcuts(phase; threshold=cut_threshold, mask)
+    changed = falses(sz)
+    delta = zeros(T, correcting ? sz : (0, 0, 0))
+    handled = falses(length(sing.loops))
+    cutmask = facemask_to_voxelmask(cuts)
+
+    if correcting
+        maxmag = magnitude_scale(mag)
+        gate = singularity_gate(mag, mask, mag_threshold, maxmag, sz)
+        allowed = isnothing(mask) ? trues(sz) : mask
+        plaq_index = plaquette_index(sing.loops)
+        cuts_components = cut_components(cutmask, allowed, sz)
+        on_loop = singularity_mask(sing)
+        for (i, loop) in enumerate(sing.loops)
+            handled[i] && continue
+            is_correctable(loop, gate; min_loop_length, max_loop_length, min_void_voxels, require_closed) || continue
+            patch = build_patch(loop, sing, cuts_components, on_loop, plaq_index, sz; dilate, pad, max_patch_voxels)
+            isnothing(patch) && continue
+            box_lo, box_hi, interior, ids = patch
+            # A line that is protected by the length limit must not be modified
+            # just because it shares a patch with a correctable one.
+            any(id -> loop_length(sing.loops[id]) > max_loop_length, ids) && continue
+            lmode = if mode == :cascade
+                loop_length(loop) ≤ small_loop_length ? :smooth : :lsq
+            else
+                mode
+            end
+            fix_patch!(phase, delta, changed, box_lo, box_hi, interior, mag, mask, lmode;
+                sigma, epsilon, maxmag)
+            for id in ids
+                handled[id] = true
+            end
+        end
+    end
+
+    return (; mode,
+        singularities=singularity_mask(sing),
+        cuts=cutmask,
+        changed, delta,
+        loops=sing.loops,
+        nloops=length(sing.loops),
+        nfixed=count(handled),
+        nskipped=length(sing.loops) - count(handled),
+        nresidues=sum(abs, sing.residues),
+        nchanged=count(changed))
+end
+
+fix_singularities!(phase::LowDim{<:Real}; mag=nothing, mask=nothing, keyargs...) =
+    fix_singularities!(to3d(phase); mag=to3d(mag), mask=to3d(mask), keyargs...)
+
+function fix_singularities!(phase::AbstractArray{T,4}; mag=nothing, keyargs...) where T
+    infos = map(1:size(phase, 4)) do i
+        m = isnothing(mag) ? nothing : view(mag, :, :, :, min(i, size(mag, 4)))
+        fix_singularities!(view(phase, :, :, :, i); mag=m, keyargs...)
+    end
+    stack4(f) = cat((getfield(info, f) for info in infos)...; dims=4)
+    return (; mode=infos[1].mode,
+        singularities=stack4(:singularities),
+        cuts=stack4(:cuts),
+        changed=stack4(:changed),
+        delta=stack4(:delta),
+        loops=[info.loops for info in infos],
+        nloops=sum(info -> info.nloops, infos),
+        nfixed=sum(info -> info.nfixed, infos),
+        nskipped=sum(info -> info.nskipped, infos),
+        nresidues=sum(info -> info.nresidues, infos),
+        nchanged=sum(info -> info.nchanged, infos),
+        echoes=infos)
+end
+
+## gating: where are we allowed to touch the phase
+magnitude_scale(mag) = isnothing(mag) ? 1.0 : max(eps(), Float64(quantile(filter(isfinite, mag), 0.95)))
+
+# The physical requirement is "don't change the phase where there is signal".
+# A singularity sits where the complex signal vanishes, so a vortex line has to
+# touch a signal void to be the case we are after. The magnitude weighting of
+# the least-squares solve enforces the same requirement a second time inside
+# the patch.
+function singularity_gate(mag, mask, mag_threshold, maxmag, sz)
+    gate = if isnothing(mag)
+        trues(sz)
+    else
+        BitArray(.!isfinite.(mag) .| (mag .< mag_threshold * maxmag))
+    end
+    if !isnothing(mask)
+        gate .&= mask
+    end
+    return gate
+end
+
+# A vortex line that leaves the volume or the mask is not closed, but it can
+# still be corrected: nothing crosses the patch boundary there. Only the part
+# of a line that stays inside must be enclosed by the patch, which is checked
+# in `build_patch`.
+function is_correctable(loop, gate; min_loop_length, max_loop_length, min_void_voxels, require_closed)
+    require_closed && !loop.closed && return false
+    min_loop_length ≤ loop_length(loop) ≤ max_loop_length || return false
+    return count(v -> gate[v], loop.voxels) ≥ min_void_voxels
+end
+
+## patch construction
+# plaquette linear index -> loop number, as a sorted vector pair
+function plaquette_index(loops)
+    keys = Int[]
+    ids = Int[]
+    for (i, l) in enumerate(loops), p in l.plaquettes
+        push!(keys, p)
+        push!(ids, i)
+    end
+    perm = sortperm(keys)
+    return keys[perm], ids[perm]
+end
+
+function build_patch(loop, sing, cuts_components, on_loop, plaq_index, sz; dilate, pad, max_patch_voxels)
+    seed = cut_seed(loop, cuts_components, sz, max_patch_voxels)
+    isnothing(seed) && return nothing
+    interior = dilate_voxels(seed, dilate, sz, max_patch_voxels)
+    isnothing(interior) && return nothing
+
+    lo, hi = voxel_bounds(interior, sz)
+    box_lo = CartesianIndex(ntuple(d -> max(1, lo[d] - pad), 3))
+    box_hi = CartesianIndex(ntuple(d -> min(sz[d], hi[d] + pad), 3))
+
+    # The net charge crossing the patch boundary has to be zero, otherwise the
+    # boundary condition is inconsistent and the error is smeared over the
+    # patch. Every vortex line touching the patch must therefore be enclosed.
+    ids = touching_loops(interior, sing, on_loop, plaq_index, sz)
+    for id in ids
+        all(v -> v in interior, sing.loops[id].voxels) || return nothing
+    end
+    return box_lo, box_hi, interior, ids
+end
+
+# The branch cut surface is bounded by the vortex line, but the minimum
+# spanning tree places it wherever the weights are worst, not necessarily next
+# to the line. The patch has to cover the whole surface, otherwise the 2π jump
+# survives outside of it. The connected components of the cut voxels are
+# labeled once for the whole volume, a patch then consists of the vortex line
+# plus the components it touches.
+function cut_components(cutmask, allowed, sz)
+    labels = zeros(Int32, sz)
+    voxels = Vector{Vector{Int}}()
+    car = CartesianIndices(sz)
+    lin = LinearIndices(sz)
+    queue = Int[]
+    for v in eachindex(labels)
+        (cutmask[v] && allowed[v] && iszero(labels[v])) || continue
+        push!(voxels, Int[])
+        label = Int32(length(voxels))
+        labels[v] = label
+        empty!(queue)
+        push!(queue, v)
+        while !isempty(queue)
+            w = pop!(queue)
+            push!(voxels[label], w)
+            I = car[w]
+            for d in 1:3, s in (-1, 1)
+                J = I + s * unitindex(d)
+                checkbounds(Bool, labels, J) || continue
+                (cutmask[J] && allowed[J] && iszero(labels[J])) || continue
+                labels[J] = label
+                push!(queue, lin[J])
+            end
+        end
+    end
+    return labels, voxels
+end
+
+function cut_seed(loop, (labels, comp_voxels), sz, limit)
+    car = CartesianIndices(sz)
+    components = Set{Int32}()
+    for v in loop.voxels
+        iszero(labels[v]) || push!(components, labels[v])
+        I = car[v]
+        for d in 1:3, s in (-1, 1)
+            J = I + s * unitindex(d)
+            checkbounds(Bool, labels, J) || continue
+            iszero(labels[J]) || push!(components, labels[J])
+        end
+    end
+    total = length(loop.voxels) + sum(c -> length(comp_voxels[c]), components; init=0)
+    total > limit && return nothing
+    seed = Set{Int}(loop.voxels)
+    for c in components, v in comp_voxels[c]
+        push!(seed, v)
+    end
+    return seed
+end
+
+function dilate_voxels(seed, r, sz, limit)
+    out = Set{Int}()
+    car = CartesianIndices(sz)
+    lin = LinearIndices(sz)
+    for v in seed
+        I = car[v]
+        for J in CartesianIndices(ntuple(d -> max(1, I[d] - r):min(sz[d], I[d] + r), 3))
+            push!(out, lin[J])
+        end
+        length(out) > limit && return nothing
+    end
+    return out
+end
+
+function voxel_bounds(voxels, sz)
+    car = CartesianIndices(sz)
+    lo = [typemax(Int), typemax(Int), typemax(Int)]
+    hi = [0, 0, 0]
+    for v in voxels
+        I = car[v]
+        for d in 1:3
+            lo[d] = min(lo[d], I[d])
+            hi[d] = max(hi[d], I[d])
+        end
+    end
+    return CartesianIndex(lo...), CartesianIndex(hi...)
+end
+
+function touching_loops(interior, sing, on_loop, (plaq_keys, plaq_ids), sz)
+    ids = Set{Int}()
+    car = CartesianIndices(sz)
+    lin = LinearIndices(sing.residues)
+    for v in interior
+        on_loop[v] || continue # only these can be a corner of a residue plaquette
+        I = car[v]
+        for c in 1:3
+            a, b = PLAQUETTE_DIMS[c]
+            ea, eb = unitindex(a), unitindex(b)
+            for P in (I, I - ea, I - eb, I - ea - eb)
+                all(>(0), Tuple(P)) || continue
+                (P[a] < sz[a] && P[b] < sz[b]) || continue
+                sing.residues[c, P] == 0 && continue
+                j = sorted_lookup(plaq_keys, lin[c, P])
+                j != 0 && push!(ids, plaq_ids[j])
+            end
+        end
+    end
+    return ids
+end
+
+## local weighted least-squares solve
+function fix_patch!(phase, delta, changed, box_lo, box_hi, interior, mag, mask, lmode; sigma, epsilon, maxmag)
+    bsz = Tuple(box_hi - box_lo) .+ 1
+    lin = LinearIndices(size(phase))
+    φ = zeros(Float64, bsz)
+    free = falses(bsz)
+    valid = falses(bsz)
+    for L in CartesianIndices(bsz)
+        I = box_lo + L - oneunit(L)
+        p = Float64(phase[I])
+        φ[L] = isfinite(p) ? p : 0.0
+        valid[L] = isfinite(p) && (isnothing(mask) || mask[I])
+        free[L] = valid[L] && (lin[I] in interior)
+    end
+    any(free) || return
+
+    W = zeros(Float64, 3, bsz...)
+    D = zeros(Float64, 3, bsz...)
+    edge_terms!(W, D, phase, mag, box_lo, valid, lmode, sigma, maxmag, epsilon)
+    solve_lsq!(φ, free, W, D)
+
+    for L in CartesianIndices(bsz)
+        (free[L] && isfinite(φ[L])) || continue
+        I = box_lo + L - oneunit(L)
+        value = eltype(phase)(φ[L])
+        value == phase[I] && continue
+        delta[I] = value - phase[I]
+        phase[I] = value
+        changed[I] = true
+    end
+    return
+end
+
+function edge_terms!(W, D, phase, mag, box_lo, valid, lmode, sigma, maxmag, epsilon)
+    bsz = size(valid)
+    box_hi = box_lo + CartesianIndex(bsz) - oneunit(box_lo)
+    S, offset = if lmode == :smooth
+        s, slo = smoothed_signal(phase, mag, box_lo, box_hi, sigma)
+        s, box_lo - slo
+    else
+        nothing, CartesianIndex(0, 0, 0)
+    end
+    for d in 1:3
+        e = unitindex(d)
+        for L in CartesianIndices(ntuple(t -> 1:(bsz[t] - (t == d)), 3))
+            M = L + e
+            (valid[L] && valid[M]) || continue
+            I = box_lo + L - oneunit(L)
+            J = I + e
+            w, Δ = if lmode == :inpaint
+                0.0, 0.0
+            elseif lmode == :smooth
+                sI, sJ = S[L+offset], S[M+offset]
+                z = sJ * conj(sI)
+                abs(sI) * abs(sJ) / maxmag^2, iszero(z) ? 0.0 : angle(z)
+            else
+                m = isnothing(mag) ? 1.0 : Float64(mag[I]) * Float64(mag[J]) / maxmag^2
+                m, rem2pi(Float64(phase[J]) - Float64(phase[I]), RoundNearest)
+            end
+            isfinite(w) || (w = 0.0)
+            isfinite(Δ) || (Δ = 0.0)
+            w = clamp(w, 0.0, 1.0)
+            W[d, L] = w + epsilon
+            D[d, L] = w * Δ / (w + epsilon)
+        end
+    end
+    return
+end
+
+# Conjugate gradient on the weighted graph Laplacian with Dirichlet boundary
+# conditions. `free` marks the unknowns, all other voxels keep their value.
+function solve_lsq!(φ, free, W, D; maxiter=2000, tol=1e-8)
+    bsz = size(φ)
+    Wsum = zeros(Float64, bsz)
+    for d in 1:3
+        e = unitindex(d)
+        for I in CartesianIndices(ntuple(t -> 1:(bsz[t] - (t == d)), 3))
+            w = W[d, I]
+            Wsum[I] += w
+            Wsum[I+e] += w
+        end
+    end
+    free = free .& (Wsum .> 0)
+    r = zeros(Float64, bsz)
+    q = zeros(Float64, bsz)
+    lsq_residual!(r, φ, free, W, D, Wsum)
+    p = copy(r)
+    rs = dotp(r, r)
+    rs0 = rs
+    iszero(rs0) && return 0.0
+    for _ in 1:maxiter
+        lsq_apply!(q, p, free, W, Wsum)
+        pq = dotp(p, q)
+        pq ≤ 0 && break
+        α = rs / pq
+        @. φ += α * p # p is zero outside of the free voxels
+        @. r -= α * q
+        rsnew = dotp(r, r)
+        if rsnew ≤ tol^2 * rs0
+            rs = rsnew
+            break
+        end
+        @. p = r + (rsnew / rs) * p
+        rs = rsnew
+    end
+    return sqrt(rs / rs0)
+end
+
+function lsq_residual!(r, φ, free, W, D, Wsum)
+    bsz = size(φ)
+    fill!(r, 0)
+    for d in 1:3
+        e = unitindex(d)
+        for I in CartesianIndices(ntuple(t -> 1:(bsz[t] - (t == d)), 3))
+            w = W[d, I]
+            iszero(w) && continue
+            J = I + e
+            r[I] += w * (φ[J] - D[d, I])
+            r[J] += w * (φ[I] + D[d, I])
+        end
+    end
+    @. r = (r - φ * Wsum) * free
+    return r
+end
+
+function lsq_apply!(q, p, free, W, Wsum)
+    bsz = size(p)
+    fill!(q, 0)
+    for d in 1:3
+        e = unitindex(d)
+        for I in CartesianIndices(ntuple(t -> 1:(bsz[t] - (t == d)), 3))
+            w = W[d, I]
+            iszero(w) && continue
+            J = I + e
+            q[I] -= w * p[J]
+            q[J] -= w * p[I]
+        end
+    end
+    @. q = (q + p * Wsum) * free
+    return q
+end
+
+function dotp(a, b)
+    s = 0.0
+    @inbounds @simd for i in eachindex(a, b)
+        s += a[i] * b[i]
+    end
+    return s
+end
+
+## complex smoothing
+function smoothed_signal(phase, mag, lo, hi, sigma)
+    sz = size(phase)
+    ext = max(1, ceil(Int, 3sigma))
+    elo = CartesianIndex(ntuple(d -> max(1, lo[d] - ext), 3))
+    ehi = CartesianIndex(ntuple(d -> min(sz[d], hi[d] + ext), 3))
+    esz = Tuple(ehi - elo) .+ 1
+    S = zeros(ComplexF64, esz)
+    for L in CartesianIndices(esz)
+        I = elo + L - oneunit(L)
+        m = isnothing(mag) ? 1.0 : Float64(mag[I])
+        p = Float64(phase[I])
+        if isfinite(m) && isfinite(p)
+            S[L] = m * cis(p)
+        end
+    end
+    smooth_complex!(S, sigma)
+    return S, elo
+end
+
+function gaussiankernel(sigma; truncate=3)
+    r = max(1, ceil(Int, truncate * sigma))
+    k = [exp(-0.5(i / sigma)^2) for i in -r:r]
+    return k ./ sum(k)
+end
+
+function smooth_complex!(S, sigma)
+    k = gaussiankernel(sigma)
+    r = (length(k) - 1) ÷ 2
+    tmp = similar(S)
+    for d in 1:3
+        size(S, d) == 1 && continue
+        convolve_dim!(tmp, S, k, r, d)
+        copyto!(S, tmp)
+    end
+    return S
+end
+
+function convolve_dim!(out, A, k, r, d)
+    sz = size(A)
+    for I in CartesianIndices(A)
+        acc = zero(eltype(A))
+        for (n, w) in enumerate(k)
+            j = clamp(I[d] + n - r - 1, 1, sz[d])
+            acc += w * A[CartesianIndex(ntuple(t -> t == d ? j : I[t], 3))]
+        end
+        out[I] = acc
+    end
+    return out
+end

--- a/src/singularity_correction.jl
+++ b/src/singularity_correction.jl
@@ -61,7 +61,15 @@ outputs, `phase` is modified in place.
 
 - `mag`: magnitude, used for the edge weights and for the gate
 - `mask`: only detect and correct inside the mask
-- `sigma=1.0`: kernel width in voxels for the complex smoothing
+- `sigma=1.0`: kernel width in voxels for the complex smoothing of the
+    `:smooth` correction mode
+- `detection_sigma=0`: if positive, the vortex lines are detected on the
+    complex signal smoothed with this kernel width instead of on the phase
+    itself (see [`detect_singularities`](@ref)). At high resolution the raw
+    residue field percolates into one connected network that no local patch can
+    enclose; smoothing separates it into individual lines. `detection_sigma`
+    also acts as a low pass on vessel size, so keep it below the radius (in
+    voxels) of the smallest vessel that matters.
 - `small_loop_length=8`: loops up to this number of residue plaquettes are
     treated as small in the `:cascade` mode
 - `min_loop_length=1`: shorter loops are not corrected (4 is the smallest
@@ -112,7 +120,7 @@ end
 
 function fix_singularities!(phase::AbstractArray{T,3};
         mode=:cascade, mag=nothing, mask=nothing,
-        sigma=1.0, small_loop_length=8, min_loop_length=1, max_loop_length=1000,
+        sigma=1.0, detection_sigma=0, small_loop_length=8, min_loop_length=1, max_loop_length=1000,
         max_patch_voxels=20_000, dilate=2, pad=2, mag_threshold=0.2,
         min_void_voxels=1, require_closed=false, epsilon=1e-3,
         cut_threshold=Float64(π), keyargs...) where T
@@ -132,19 +140,25 @@ function fix_singularities!(phase::AbstractArray{T,3};
     end
 
     mask = tomask(mask)
-    sing = detect_singularities(phase; mask)
-    cuts = branchcuts(phase; threshold=cut_threshold, mask)
+    # The vortex lines and the branch cuts that the patches grow along have to
+    # come from the same field, otherwise the patch is grown along a structure
+    # that has nothing to do with the detected line.
+    detection_phase = detection_sigma > 0 ? smoothed_phase(phase, mag, detection_sigma, mask) : phase
+    sing = detect_singularities(detection_phase; mask)
+    cuts = branchcuts(phase; threshold=cut_threshold, mask) # reported: the real jumps of the output
+    growth_cuts = detection_sigma > 0 ? branchcuts(detection_phase; threshold=cut_threshold, mask) : cuts
     changed = falses(sz)
     delta = zeros(T, correcting ? sz : (0, 0, 0))
     handled = falses(length(sing.loops))
     cutmask = facemask_to_voxelmask(cuts)
+    growth_mask = detection_sigma > 0 ? facemask_to_voxelmask(growth_cuts) : cutmask
 
     if correcting
         maxmag = magnitude_scale(mag)
         gate = singularity_gate(mag, mask, mag_threshold, maxmag, sz)
         allowed = isnothing(mask) ? trues(sz) : mask
         plaq_index = plaquette_index(sing.loops)
-        cuts_components = cut_components(cutmask, allowed, sz)
+        cuts_components = cut_components(growth_mask, allowed, sz)
         on_loop = singularity_mask(sing)
         for (i, loop) in enumerate(sing.loops)
             handled[i] && continue

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,4 +2,6 @@
 ArgParse = "c7e460c6-2fb9-53a9-8c5b-16f535851c63"
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 MriResearchTools = "557dad86-b9bd-4533-8525-1a39684d020f"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/RomeoApp/dataset_small.jl
+++ b/test/RomeoApp/dataset_small.jl
@@ -64,6 +64,8 @@ configurations_se(pm) = [
     [pm..., "-k", "nomask"],
     [pm..., "-k", "qualitymask"],
     [pm..., "-k", "qualitymask", "0.1"],
+    [pm..., "--fix-singularities"],
+    [pm..., "--fix-singularities", "cascade"],
 ]
 configurations_me(phasefile_me, magfile_me) = vcat(configurations_me.([[phasefile_me], [phasefile_me, "-m", magfile_me]])...)
 configurations_me(pm) = [
@@ -206,6 +208,31 @@ unwrapping_main([phasefile_me, "-o", testpath, "-m", magfile_me, "-t", "[2,4,6]"
 @test isfile(joinpath(testpath, "$(name)_snr.nii"))
 
 ## TODO add and test homogeneity corrected output
+
+## test singularity output files
+base_args = [phasefile_me, "-m", magfile_me, "-t", "[2,4,6]"]
+refpath = joinpath(tmpdir, "test_singularities_ref")
+unwrapping_main([base_args..., "-o", refpath])
+
+testpath = joinpath(tmpdir, "test_singularities_mask")
+unwrapping_main([base_args..., "-o", testpath, "--fix-singularities"])
+@test isfile(joinpath(testpath, "singularities.nii"))
+@test isfile(joinpath(testpath, "branchcuts.nii"))
+@test !isfile(joinpath(testpath, "phase_correction.nii")) # "mask" must not change the phase
+@test niread(joinpath(testpath, "unwrapped.nii")).raw == niread(joinpath(refpath, "unwrapped.nii")).raw
+
+testpath = joinpath(tmpdir, "test_singularities_cascade")
+unwrapping_main([base_args..., "-o", testpath, "--fix-singularities", "cascade"])
+@test isfile(joinpath(testpath, "singularities.nii"))
+@test isfile(joinpath(testpath, "phase_correction.nii"))
+@test isfile(joinpath(testpath, "singularities_corrected.nii"))
+
+for mode in ["lsq", "smooth", "inpaint"]
+    test_romeo([base_args..., "--fix-singularities", mode])
+end
+
+m = "fix-singularities option 'blub' is undefined! Use one of off, mask, smooth, lsq, inpaint, cascade"
+@test_throws ErrorException(m) unwrapping_main([phasefile_1eco, "-o", tmpdir, "--fix-singularities", "blub"])
 
 ## test quality map
 unwrapping_main([phasefile_me, "-m", magfile_me, "-o", tmpdir, "-t", "[2,4,6]", "-qQ"])

--- a/test/RomeoApp/dataset_small.jl
+++ b/test/RomeoApp/dataset_small.jl
@@ -230,6 +230,8 @@ unwrapping_main([base_args..., "-o", testpath, "--fix-singularities", "cascade"]
 for mode in ["lsq", "smooth", "inpaint"]
     test_romeo([base_args..., "--fix-singularities", mode])
 end
+test_romeo([base_args..., "--fix-singularities", "mask", "--singularity-sigma", "1.0"])
+test_romeo([base_args..., "--fix-singularities", "cascade", "--singularity-sigma", "0.7"])
 
 m = "fix-singularities option 'blub' is undefined! Use one of off, mask, smooth, lsq, inpaint, cascade"
 @test_throws ErrorException(m) unwrapping_main([phasefile_1eco, "-o", tmpdir, "--fix-singularities", "blub"])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ nan_test(I1, I2) = I1[.!isnan.(I1)] ≈ I2[.!isnan.(I2)]
     include("dsp_tests.jl")
     include("mri.jl")
     include("voxelquality.jl")
+    include("singularities.jl")
     #include("timing.jl")
 end
 

--- a/test/singularities.jl
+++ b/test/singularities.jl
@@ -1,0 +1,151 @@
+using Statistics
+include("vein_phantom.jl")
+
+@testset "Singularities" begin
+
+# S = (ρ - R) + iz has its zero line on the ring ρ=R, z=0, so the phase of S
+# contains exactly one closed vortex line of a known size.
+function vortex_ring(sz=(31, 31, 15); R=8.0)
+    c = (sz .+ 1) ./ 2
+    return [atan(I[3] - c[3], sqrt((I[1] - c[1])^2 + (I[2] - c[2])^2) - R) for I in CartesianIndices(sz)]
+end
+
+ring = vortex_ring()
+sz = size(ring)
+s = detect_singularities(ring)
+ph = vein_phantom()
+
+## detection
+@test length(s.loops) == 1
+@test s.loops[1].closed
+@test ROMEO.loop_length(s.loops[1]) == 60
+@test sum(abs, s.residues) == 60
+@test count(singularity_mask(s)) == length(s.loops[1].voxels)
+@test !any(singularity_mask(s; min_length=100))
+
+## the residue field is divergence free, therefore the lines are closed
+@test all(ROMEO.cube_divergence(s.residues, J) == 0 for J in CartesianIndices(ntuple(d -> 1:sz[d]-1, 3)))
+
+## residues only depend on the wrapped differences (congruence invariance)
+unwrapped = unwrap(ring)
+@test residues(unwrapped) == residues(ring)
+# the ring has phase differences of exactly π (the ambiguous case of rem2pi),
+# the phantom phase is generic
+congruent = ph.phase .+ 2π .* [iseven(sum(Tuple(I))) ? 1 : -2 for I in CartesianIndices(size(ph.phase))]
+@test residues(congruent) == residues(ph.phase)
+@test residues(unwrap(ph.phase; mag=ph.mag)) == residues(ph.phase)
+
+## masked detection
+mask = falses(sz)
+mask[10:20, 10:20, :] .= true
+@test sum(abs, residues(ring; mask)) < sum(abs, residues(ring))
+
+## smooth phase: no residues, no branch cuts, correction is a no-op
+ramp = [0.3I[1] + 0.2I[2] - 0.1I[3] for I in CartesianIndices((20, 20, 20))]
+smooth_uw = unwrap(rem2pi.(ramp, RoundNearest))
+@test sum(abs, residues(smooth_uw)) == 0
+@test count(branchcuts(smooth_uw)) == 0
+before = copy(smooth_uw)
+info = fix_singularities!(smooth_uw; mode=:cascade)
+@test smooth_uw == before # bit identical
+@test info.nchanged == 0
+@test !any(info.singularities)
+
+## a residue leaves a branch cut in the congruent ROMEO result
+@test count(branchcuts(unwrapped)) > 0
+
+## correction
+for mode in (:lsq, :inpaint, :smooth, :cascade)
+    uw = unwrap(ring)
+    orig = copy(uw)
+    info = fix_singularities!(uw; mode)
+    @test info.nfixed == 1
+    @test info.nskipped == 0
+    @test count(branchcuts(uw)) == 0 # the branch cut is gone
+    @test uw[.!info.changed] == orig[.!info.changed] # bit identical outside
+    @test all(info.delta[.!info.changed] .== 0)
+    @test 0 < info.nchanged < length(uw) / 3
+end
+
+## :mask only detects, :off does nothing at all
+uw = unwrap(ring)
+orig = copy(uw)
+info = fix_singularities!(uw; mode=:mask)
+@test uw == orig
+@test any(info.singularities)
+@test any(info.cuts)
+@test isempty(info.delta)
+@test info.nchanged == 0
+
+info = fix_singularities!(uw; mode=:off)
+@test uw == orig
+@test info.nloops == 0
+@test !any(info.singularities)
+
+@test_throws ArgumentError fix_singularities!(copy(uw); mode=:nonsense)
+
+## fallback rules: too long, too large or not dark enough is only marked
+info = fix_singularities!(copy(uw); mode=:lsq, max_loop_length=10)
+@test info.nfixed == 0 && info.nskipped == 1
+info = fix_singularities!(copy(uw); mode=:lsq, max_patch_voxels=10)
+@test info.nfixed == 0 && info.nskipped == 1
+info = fix_singularities!(copy(uw); mode=:lsq, mag=ones(sz)) # no signal void -> don't touch
+@test info.nfixed == 0 && info.nskipped == 1
+info = fix_singularities!(copy(uw); mode=:lsq, mag=ones(sz), min_void_voxels=0)
+@test info.nfixed == 1
+
+## non-mutating version
+fixed, info = fix_singularities(uw; mode=:cascade)
+@test uw == orig
+@test fixed != uw
+@test count(branchcuts(fixed)) == 0
+
+## NaN input must not crash
+nanring = copy(uw)
+nanring[1, :, :] .= NaN
+info = fix_singularities!(nanring; mode=:cascade)
+@test isfinite(sum(filter(isfinite, nanring)))
+
+## vein phantom: the singularities appear on their own, not put in by hand
+TE = 25e-3
+truth = 2π .* ph.field .* TE
+@test sum(abs, residues(ph.phase)) > 0
+
+uw = unwrap(ph.phase; mag=ph.mag)
+orig = copy(uw)
+info = fix_singularities!(uw; mag=ph.mag, mode=:cascade)
+@test info.nfixed > 0
+@test sum(abs, residues(uw)) < 0.1 * sum(abs, residues(orig))
+@test count(branchcuts(uw)) < 0.1 * count(branchcuts(orig))
+
+# protection metrics
+@test uw[.!info.changed] == orig[.!info.changed]
+@test info.nchanged == count(info.changed)
+mag_median = median(ph.mag)
+@test count(info.changed[ph.mag.≥mag_median]) == 0 # only low signal voxels are touched
+top_decile = ph.mag .≥ quantile(vec(ph.mag), 0.9)
+@test maximum(congruence_error(uw, orig)[top_decile]) == 0
+
+# the correction has to move the phase towards the true field
+align(x) = x .- 2π * round(median(x .- truth) / 2π)
+rmse(x) = sqrt(sum(abs2, align(x) .- truth) / length(x))
+@test rmse(uw) < 0.7 * rmse(orig)
+
+## negative control: 1mm, 3T, short TE should not produce singularities at all
+lowres = vein_phantom(; sz=(24, 24, 12), voxelsize=1.0, radius=0.5, B0=3.0, TE=8e-3)
+@test sum(abs, residues(lowres.phase)) == 0
+
+## 4D
+ph4 = cat(ph.phase, ph.phase; dims=4)
+mag4 = cat(ph.mag, ph.mag; dims=4)
+uw4 = unwrap(ph4; mag=mag4, TEs=[1, 2])
+orig4 = copy(uw4)
+info4 = fix_singularities!(uw4; mag=mag4, mode=:mask)
+@test size(info4.singularities) == size(ph4)
+@test info4.nchanged == 0 && uw4 == orig4
+info4 = fix_singularities!(uw4; mag=mag4, mode=:cascade)
+@test size(info4.delta) == size(ph4)
+@test uw4[.!info4.changed] == orig4[.!info4.changed]
+@test info4.nfixed > 0
+
+end

--- a/test/singularities.jl
+++ b/test/singularities.jl
@@ -131,6 +131,32 @@ align(x) = x .- 2π * round(median(x .- truth) / 2π)
 rmse(x) = sqrt(sum(abs2, align(x) .- truth) / length(x))
 @test rmse(uw) < 0.7 * rmse(orig)
 
+## detection on the complex-smoothed signal (`sigma`)
+# noise residues annihilate as ± pairs inside the kernel
+noisy = let ramp = [0.3I[1] + 0.2I[2] - 0.1I[3] for I in CartesianIndices((30, 30, 30))]
+    seed = [sin(13I[1]) + cos(7I[2] + 2I[3]) for I in CartesianIndices((30, 30, 30))] # deterministic
+    seed2 = [cos(11I[1] + 3I[3]) - sin(5I[2]) for I in CartesianIndices((30, 30, 30))]
+    S = cis.(ramp) .+ 0.9 .* complex.(seed, seed2)
+    (phase=angle.(S), mag=abs.(S))
+end
+@test sum(abs, residues(noisy.phase)) > 100
+@test sum(abs, detect_singularities(noisy.phase; mag=noisy.mag, sigma=1).residues) <
+      0.2 * sum(abs, residues(noisy.phase))
+
+# the vessel singularities of the phantom survive a kernel smaller than the vessel
+s_smooth = detect_singularities(ph.phase; mag=ph.mag, sigma=0.7)
+inside(a, b) = all(v -> any(w -> maximum(abs.(Tuple(CartesianIndices(size(ph.phase))[v] -
+                                               CartesianIndices(size(ph.phase))[w]))) <= 2, b), a)
+@test count(singularity_mask(s_smooth)) > 0
+@test inside(findall(singularity_mask(s_smooth)), findall(singularity_mask(detect_singularities(ph.phase))))
+
+# and the correction can be driven from the smoothed detection
+uw_ds = unwrap(ph.phase; mag=ph.mag)
+orig_ds = copy(uw_ds)
+info_ds = fix_singularities!(uw_ds; mag=ph.mag, mode=:cascade, detection_sigma=0.7)
+@test uw_ds[.!info_ds.changed] == orig_ds[.!info_ds.changed]
+@test info_ds.nloops < info.nloops # fewer, cleaner lines than without smoothing
+
 ## negative control: 1mm, 3T, short TE should not produce singularities at all
 lowres = vein_phantom(; sz=(24, 24, 12), voxelsize=1.0, radius=0.5, B0=3.0, TE=8e-3)
 @test sum(abs, residues(lowres.phase)) == 0

--- a/test/vein_phantom.jl
+++ b/test/vein_phantom.jl
@@ -1,0 +1,91 @@
+## Numerical vein phantom
+#
+# A cylindrical vessel with the susceptibility difference `dchi` at the angle
+# `theta` to B0 is placed in a box. The analytic field of an infinite cylinder
+# is evaluated on a `sub`^3 subgrid, the complex signal (with T2* decay) is
+# generated there and averaged over the subvoxels of each voxel.
+#
+# Nothing is put in by hand: the partial voluming at the vessel wall and the
+# intravoxel dephasing in the steep dipole field make the complex signal cross
+# zero somewhere, which is exactly the mechanism that creates phase
+# singularities in high resolution in-vivo data. The phantom therefore delivers
+# singularities together with the true field map.
+
+using Random
+
+const γ_over_2π = 42.577478e6 # Hz/T
+
+"""
+    vein_phantom(; keyargs...)
+
+Returns `(; phase, mag, complex, field, vein)` for a single straight vessel.
+`field` is the true frequency offset in Hz, `vein` the true intravascular mask
+(both on the voxel grid), `phase` is wrapped to [-π;π].
+"""
+function vein_phantom(;
+        sz=(40, 40, 24),
+        voxelsize=0.3,          # mm, isotropic
+        radius=0.45,            # mm, vessel radius
+        theta=deg2rad(70),      # angle between vessel and B0
+        dchi=0.4e-6,            # susceptibility difference vein - tissue
+        B0=7.0,                 # T
+        TE=25e-3,               # s
+        T2s_tissue=25e-3,
+        T2s_blood=8e-3,
+        rho_tissue=1.0,
+        rho_blood=1.0,
+        sub=3,                  # subvoxels per dimension
+        noise=0.0,
+        seed=0,
+        )
+    rng = MersenneTwister(seed)
+    axis = (sin(theta), 0.0, cos(theta))            # vessel direction
+    # projection of B0 (z) into the plane perpendicular to the vessel
+    zperp = (0.0, 0.0, 1.0) .- cos(theta) .* axis
+    nzperp = sqrt(sum(abs2, zperp))
+    zperp = nzperp > 0 ? zperp ./ nzperp : (1.0, 0.0, 0.0)
+
+    center = (sz .+ 1) ./ 2
+    S = zeros(ComplexF64, sz)
+    field = zeros(Float64, sz)
+    vein = falses(sz)
+    step = voxelsize / sub
+    offsets = ((1:sub) .- (sub + 1) / 2) .* step
+
+    for I in CartesianIndices(sz)
+        acc = zero(ComplexF64)
+        facc = 0.0
+        inside_count = 0
+        for dx in offsets, dy in offsets, dz in offsets
+            r = ((I[1] - center[1]) * voxelsize + dx,
+                 (I[2] - center[2]) * voxelsize + dy,
+                 (I[3] - center[3]) * voxelsize + dz)
+            f, inside = cylinder_frequency(r, axis, zperp, radius, dchi, theta, B0)
+            inside_count += inside
+            facc += f
+            m = inside ? rho_blood * exp(-TE / T2s_blood) : rho_tissue * exp(-TE / T2s_tissue)
+            acc += m * cis(2π * f * TE)
+        end
+        n = sub^3
+        S[I] = acc / n
+        field[I] = facc / n
+        vein[I] = 2inside_count > n
+    end
+    if noise > 0
+        S .+= noise .* complex.(randn(rng, sz), randn(rng, sz))
+    end
+    return (; phase=angle.(S), mag=abs.(S), complex=S, field, vein)
+end
+
+# analytic field of an infinite cylinder (Lorentz sphere corrected)
+function cylinder_frequency(r, axis, zperp, radius, dchi, theta, B0)
+    along = sum(r .* axis)
+    perp = r .- along .* axis
+    ρ = sqrt(sum(abs2, perp))
+    if ρ ≤ radius
+        return γ_over_2π * B0 * dchi / 6 * (3cos(theta)^2 - 1), true
+    end
+    cosφ = sum(perp .* zperp) / ρ
+    cos2φ = 2cosφ^2 - 1
+    return γ_over_2π * B0 * dchi / 2 * (radius / ρ)^2 * sin(theta)^2 * cos2φ, false
+end


### PR DESCRIPTION
In high resolution data the complex signal can cross zero at a vessel
wall, where two compartments with roughly opposite phase cancel each
other. The wrapped phase then has a non-zero circulation (a residue),
which is a topological obstruction: no congruent unwrapping exists. In
3D the residue field is divergence free, so residues form closed lines,
around a vein typically rings that encircle the vessel. ROMEO stays
congruent and can only move the resulting branch cut to the worst
weights, it cannot remove it.

Detection (parameter free, O(N), works on wrapped or unwrapped phase):

- `residues`: charge of every 2x2 plaquette, as a divergence free field
- `detect_singularities`: groups the residues into vortex lines
- `singularity_mask`, `branchcuts`, `congruence_error`

Correction (`fix_singularities!`, off by default): every mode solves the
same local weighted least-squares problem on a patch that encloses the
vortex line and its branch cut surface, with the ROMEO result as
Dirichlet boundary condition. Outside of the patch the phase stays
bit-identical and therefore congruent. The modes differ only in the edge
confidence w and the target gradient:

- `:mask`    only detect, e.g. as a data term weight for QSM
- `:cascade` complex smoothing for small loops, weighted LS for large ones
- `:lsq`     magnitude weighted least squares
- `:smooth`  gradients from the complex signal smoothed with sigma
- `:inpaint` w = 0, degenerates to harmonic inpainting (control arm)

Lines that are too long, that need too large a patch, or that do not
touch a signal void are only marked, never modified. This protects real
pathology such as microbleeds and implants.

CLI: `--fix-singularities [off|mask|cascade|smooth|lsq|inpaint]`,
default off, writes singularities.nii, branchcuts.nii and (for the
correcting modes) phase_correction.nii with the applied delta.

Tests add a numerical vein phantom that generates the singularities from
partial voluming and intravoxel dephasing on a subgrid, together with
the true field map, plus a synthetic vortex ring with a known loop
length and a 1mm/3T/short-TE negative control. On the phantom the
correction reduces the RMSE against the true field from 0.64 to 0.27 rad
while voxels above the median magnitude stay bit-identical.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01B6Tq8ZBPhoawVas937FnBx