### PR TITLE
Fix hyphenated filenames in the CLI, tidy the provenance exports, drop nightly from CI

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,11 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    groups:
+      # One pull request per month for all action bumps, instead of one per
+      # action. Ungrouped weekly updates produced five or more open pull
+      # requests per repository that nobody triaged.
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,10 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
+    # 'nightly' tracks unreleased Julia, so a failure there is upstream breakage
+    # rather than a defect in this package. The job still runs and still reports,
+    # but it no longer fails the workflow run.
+    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,10 +14,6 @@ jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
-    # 'nightly' tracks unreleased Julia, so a failure there is upstream breakage
-    # rather than a defect in this package. The job still runs and still reports,
-    # but it no longer fails the workflow run.
-    continue-on-error: ${{ matrix.version == 'nightly' }}
     strategy:
       fail-fast: false
       matrix:
@@ -25,7 +21,12 @@ jobs:
           - 'min'
           - 'lts'
           - '1'
-          - 'nightly'
+          # 'nightly' is deliberately absent. A failure there is upstream
+          # breakage in unreleased Julia, not a defect here, but the check run
+          # for the job still reports its own failure even with
+          # continue-on-error, so every pull request read as broken. Measured on
+          # ROMEO.jl#21: run conclusion success, nightly job conclusion failure,
+          # red X in the checks list.
         os:
           - ubuntu-latest
         arch:

--- a/ext/RomeoApp/argparse.jl
+++ b/ext/RomeoApp/argparse.jl
@@ -2,8 +2,14 @@ function getargs(args::AbstractVector, version)
     if isempty(args)
         args = ["--help"]
     else
-        if !('-' in args[1]) prepend!(args, Ref("-p")) end # if phase is first without -p
-        if length(args) >= 2 && !("-p" in args || "--phase" in args) && !('-' in args[end-1]) # if phase is last without -p
+        # `startswith`, not `'-' in`: the latter asked whether a hyphen appears
+        # anywhere in the string, so any filename containing one looked like a
+        # flag and did not get `-p` prepended. ArgParse then rejected it as a
+        # stray positional. BIDS names are made of hyphens
+        # (sub-01_part-phase_MEGRE.nii), so the documented form
+        # `romeo phase.nii -t ...` failed for most real datasets.
+        if !startswith(args[1], '-') prepend!(args, Ref("-p")) end # if phase is first without -p
+        if length(args) >= 2 && !("-p" in args || "--phase" in args) && !startswith(args[end-1], '-') # if phase is last without -p
             insert!(args, length(args), "-p")
         end
     end

--- a/src/ROMEO.jl
+++ b/src/ROMEO.jl
@@ -18,6 +18,6 @@ include("provenance.jl")
 unwrapping_main(args...; kwargs...) = @warn("Type `using ArgParse` to use this function \n `?unwrapping_main` for argument help")
 
 export unwrap, unwrap!, unwrap_individual, unwrap_individual!, voxelquality, unwrapping_main,
-       write_provenance, register_citation!, CITATIONS, NOTICES
+       write_provenance, write_citations, register_citation!
 
 end # module

--- a/src/algorithm.jl
+++ b/src/algorithm.jl
@@ -4,6 +4,15 @@ function grow_region_unwrap!(
     )
     ## Init
     maxseeds = min(255, maxseeds) # Hard Limit, Stored in UInt8
+    # The arithmetic should follow the data, not the type of an option. In
+    # unwrapedge! `d` is one of `-x`, `x` or `v::eltype(wrapped)`, so a
+    # wrap_addition of a different type makes `d` a small Union in the innermost
+    # loop of the unwrapper: Int gives Union{Float32,Int64}, Float64 gives
+    # Union{Float32,Float64}, and only a matching eltype infers concretely.
+    # Converting once here fixes that for every caller, including the CLI, which
+    # passes the value through a Dict{Symbol,Any}. Output is unchanged: Int 0,
+    # 0.0 and 0.0f0 give bit-identical results on the test data.
+    wrap_addition = convert(eltype(wrapped), wrap_addition)
     dimoffsets = getdimoffsets(wrapped)
     notvisited(i) = checkbounds(Bool, visited, i) && (visited[i] == 0)
     seeds = Int[]

--- a/src/provenance.jl
+++ b/src/provenance.jl
@@ -121,7 +121,7 @@ function write_provenance(dir, tool; version, args, settings, cite,
     dir = abspath(dir)
     mkpath(dir)
     _write_settings(dir, tool; version, args, settings, inputs, packages, describe)
-    _write_citations(dir, tool; cite, optional)
+    write_citations(dir, tool; cite, optional)
     return dir
 end
 
@@ -157,7 +157,23 @@ function _write_settings(dir, tool; version, args, settings, inputs, packages, d
     end
 end
 
-function _write_citations(dir, tool; cite, optional)
+"""
+    write_citations(dir, tool; cite, optional=Symbol[])
+
+Write `citations_<tool>.txt` into `dir`, covering only the methods named in
+`cite`. Keys are looked up in the citation registry, which each package fills in
+for the methods it implements (see [`register_citation!`](@ref)); a key with no
+registered citation is warned about rather than silently omitted, because a
+missing reference is the failure this is meant to prevent. Any notice attached to
+a used method is written below the references, and `optional` keys that are
+registered but were not used are listed separately.
+
+The registry itself is `ROMEO.CITATIONS` and `ROMEO.NOTICES`. Both are
+deliberately not exported: the names are too generic to put in every user's
+namespace, and `register_citation!` plus this function are the intended
+interface.
+"""
+function write_citations(dir, tool; cite, optional=Symbol[])
     known = filter(k -> haskey(CITATIONS, k), unique(cite))
     missing_keys = setdiff(unique(cite), known)
     if !isempty(missing_keys)

--- a/test/RomeoApp/dataset_small.jl
+++ b/test/RomeoApp/dataset_small.jl
@@ -214,6 +214,24 @@ for i in 1:length(fns), j in i+1:length(fns)
     @test niread(fns[i]).raw != niread(fns[j]).raw
 end
 
+## a filename containing a hyphen must still be recognised as the phase input.
+## `'-' in args[1]` used to treat any such name as a flag, so the documented
+## positional form failed on BIDS names.
+for name in ["sub-01_part-phase_MEGRE.nii", "no_hyphen_here.nii"]
+    hyphenated = joinpath(tmpdir, name)
+    cp(phasefile_me, hyphenated; force=true)
+    testpath = joinpath(tmpdir, "hyphen_" * replace(name, "." => "_"))
+    @test unwrapping_main([hyphenated, "-o", testpath, "-t", "[2,4,6]"]) == 0
+    @test isfile(joinpath(testpath, "unwrapped.nii"))
+end
+
+## the same name given last, the other branch of the same guard
+trailing = joinpath(tmpdir, "sub-02_part-phase_MEGRE.nii")
+cp(phasefile_me, trailing; force=true)
+testpath = joinpath(tmpdir, "hyphen_trailing")
+@test unwrapping_main(["-o", testpath, "-t", "[2,4,6]", trailing]) == 0
+@test isfile(joinpath(testpath, "unwrapped.nii"))
+
 cd(original_path)
 GC.gc()
 rm(tmpdir, recursive=true)

--- a/test/provenance.jl
+++ b/test/provenance.jl
@@ -3,10 +3,10 @@
 # ROMEO carries the writer and the references for its own methods, and nothing
 # else. Anything more would mean a package knowing about methods it does not
 # implement.
-@test haskey(CITATIONS, :romeo)
-@test haskey(CITATIONS, :bestpath)
-@test !haskey(CITATIONS, :clearswi)
-@test !haskey(CITATIONS, :tgv)
+@test haskey(ROMEO.CITATIONS, :romeo)
+@test haskey(ROMEO.CITATIONS, :bestpath)
+@test !haskey(ROMEO.CITATIONS, :clearswi)
+@test !haskey(ROMEO.CITATIONS, :tgv)
 
 settings = Dict{String,Any}(
     "phase" => "p.nii",
@@ -41,11 +41,11 @@ c = read(joinpath(dir, "citations_tool.txt"), String)
 
 # Registering is idempotent for identical text, and complains when two packages
 # disagree about a reference rather than silently keeping one.
-n = length(CITATIONS)
-register_citation!(:romeo, CITATIONS[:romeo])
-@test length(CITATIONS) == n
+n = length(ROMEO.CITATIONS)
+register_citation!(:romeo, ROMEO.CITATIONS[:romeo])
+@test length(ROMEO.CITATIONS) == n
 @test_logs (:warn,) register_citation!(:romeo, "something else entirely")
-@test occursin("Rapid Opensource", CITATIONS[:romeo]) # first registration kept
+@test occursin("Rapid Opensource", ROMEO.CITATIONS[:romeo]) # first registration kept
 
 # A method whose owning package is not loaded must be reported, not silently
 # dropped: a missing citation is the failure this file exists to prevent.
@@ -61,6 +61,6 @@ write_provenance(dir3, "t3"; version="1", args=String[], settings=Dict{String,An
 c3 = read(joinpath(dir3, "citations_t3.txt"), String)
 @test count("Some Reference.", c3) == 1
 @test occursin("A NOTICE.", c3)
-delete!(CITATIONS, :test_method); delete!(NOTICES, :test_method)
+delete!(ROMEO.CITATIONS, :test_method); delete!(ROMEO.NOTICES, :test_method)
 
 end


### PR DESCRIPTION
Follow-up to #20, which is merged. Four changes, the first one worth doing before 1.5.0 is registered.

## A hyphen anywhere in the filename broke the positional phase argument

`getargs` decided whether the first argument was a flag with `'-' in args[1]`, which asks whether a hyphen occurs anywhere in the string rather than whether the argument *starts* with one. Any filename containing a hyphen was therefore taken for a flag, `-p` was not prepended, and ArgParse rejected the path as a stray positional:

```
$ romeo sub-01_part-phase_MEGRE.nii -t "[2,4,6]" -o out
wrong argument formatting!
too many arguments
usage: <PROGRAM> [-p PHASE] ...
```

The same file copied to `plainphase.nii` parses fine, so the filename is the only variable. BIDS names are built from hyphens, and the README documents exactly this form (`romeo phase.nii -m mag.nii -t [2.1,4.2,6.3] -o results`), so the documented invocation fails on most real datasets and exits 1 with a message that reads like user error. The trailing form has the same guard on `args[end-1]`.

Not a regression: the guard is byte-identical in 1.4.0. It stayed hidden because the test suite only ever ran from paths that happen to contain no hyphen, on CI runners as well as on a normal checkout. The 2x2:

| Code | Path contains a hyphen | Result |
|---|---|---|
| master | no | 217 + 578 pass |
| master | yes | 217 pass, RomeoApp dies, `wrong argument formatting` |
| this PR | no | 217 + 584 pass |
| this PR | yes | 217 + 584 pass |

The regression test copies the phase file to `sub-01_part-phase_MEGRE.nii` and runs the CLI on it positionally, first and last, with a non-hyphenated name as the control, so it no longer depends on where the suite runs from.

`romeo_mask` in CompileMRI.jl carries a hand-copy of the same guard and is fixed there too.

## The citation registry is no longer exported

`CITATIONS` and `NOTICES` were exported, putting two very generic names into the namespace of everyone who types `using ROMEO`. Any package exporting either would make `using ROMEO, ThatPackage` ambiguous, and once a registered release exports a name, removing it is breaking. Nothing released exports them yet.

They stay reachable as `ROMEO.CITATIONS` / `ROMEO.NOTICES`, and the docstring says why they are not exported.

Un-exporting them left CLEARSWI with no way to reach the registry, since it has no direct ROMEO dependency, and that turned out to be the useful part: CLEARSWI's `write_citations_swi` was a near-copy of the private `_write_citations` here and had drifted twice. It printed the notices header once per notice, and it skipped an unregistered citation **silently**, which is precisely the failure this machinery exists to prevent. So `_write_citations` becomes the exported, documented `write_citations`, and CLEARSWI calls it.

Exports go from `write_provenance, register_citation!, CITATIONS, NOTICES` to `write_provenance, write_citations, register_citation!`.

## `wrap_addition` follows the data, not the option

In `unwrapedge!`, `d` is one of `-x`, `x` or `v::eltype(wrapped)`. An `if` does not promote, so the inferred type of `d` in the innermost loop of the unwrapper followed the option:

| `wrap_addition` | inferred `d` |
|---|---|
| `0` (`Int`, pre-adb695a default) | `Union{Float32, Int64}` |
| `0.0` (`Float64`, current default) | `Union{Float32, Float64}` |
| `0.0f0` (matching eltype) | `Float32` |

adb695a changed the default from `0` to `0.0` so the library and the CLI would agree, but that swapped one union for the other rather than removing it, and the CLI passes the value through a `Dict{Symbol,Any}` so it arrives as `Any` regardless. `grow_region_unwrap!` now converts once, before the loop, so every caller behaves identically and the branch infers concretely.

Output is unchanged: `0`, `0.0` and `0.0f0` give bit-identical results on the test data (sum `-290646.6460571289`, `ndiff = 0`).

## CI

Dependabot moves from weekly and per-action to monthly and grouped into one pull request.

`nightly` is removed from the matrix. The first attempt used `continue-on-error`, which turned out to be the wrong lever: it changes the workflow **run** conclusion, but the check run for the individual job keeps its own conclusion, and that is what a pull request renders. Measured on this PR:

```
Julia min       success
Julia lts       success
Julia 1         success
Documentation   success
Julia nightly   failure    <- red X on the pull request
workflow run    success
```

So the PR still read as broken, which was the whole point of the change. There is no setting that makes a failing job report green, so nightly is dropped and `min` / `lts` / `1` remain.

What it was catching is real but not actionable here: two genuine upstream breaks on Julia 1.14, FFTW passing an `Expr` as a `ccall` library name and an Interpolations syntax error, with MriResearchTools and RomeoApp cascading off FFTW. All reproduce on master. If the signal is wanted back, a separate scheduled workflow against master would give it without ever touching a pull request's checks list.

## Verification

217 + 584 assertions, exit 0, on 4 threads so `test/threading.jl` is live. Also run against the **registered** MriResearchTools 3.5.0 with no source overrides, which is what CI does.